### PR TITLE
Improve error reporting when sqlite3 is missing

### DIFF
--- a/src/PowerShellUniversal.Apps.HerdManager/PowerShellUniversal.Apps.HerdManager.psm1
+++ b/src/PowerShellUniversal.Apps.HerdManager/PowerShellUniversal.Apps.HerdManager.psm1
@@ -46,8 +46,30 @@ if (-not (Test-Path $BasePath)) {
 }
 
 # Initialize DB + schema (idempotent)
-Initialize-HerdDbFile -Database $script:DatabasePath
-Initialize-HerdDatabase -Schema $SchemaPath -Database $script:DatabasePath
+try {
+    Initialize-HerdDbFile -Database $script:DatabasePath
+    Initialize-HerdDatabase -Schema $SchemaPath -Database $script:DatabasePath
+}
+catch {
+    $border = "=" * 72
+    # Wrap the error text for readability in logs
+    $innerMsg = "$_" -replace '(\.\s)', ".`n "
+    $errMsg = @"
+
+$border
+ HERD MANAGER - INITIALIZATION FAILED
+$border
+ $innerMsg
+$border
+"@
+
+    # Surface the error in the PSU app log if running inside PSU
+    if (Get-Command Write-PSULog -ErrorAction SilentlyContinue) {
+        Write-PSULog -Feature "App" -Resource "Herd Manager" -Level Error -Message $errMsg
+    }
+
+    throw $errMsg
+}
 
 # Ensure sensible PRAGMA settings for concurrency/ durability even if DB already existed
 try {

--- a/src/PowerShellUniversal.Apps.HerdManager/dashboards/HerdManager/HerdManager.ps1
+++ b/src/PowerShellUniversal.Apps.HerdManager/dashboards/HerdManager/HerdManager.ps1
@@ -37,7 +37,7 @@ begin {
     
         # Verify sqlite3 is available
         if (-not (Get-Command sqlite3 -ErrorAction SilentlyContinue)) {
-            throw "sqlite3 command not found. Please install SQLite."
+            throw "sqlite3 command not found. Download sqlite3 from https://www.sqlite.org/download.html and add it to your system PATH. If running under PowerShell Universal, restart the PSU service after updating PATH."
         }
     
         # Verify database exists

--- a/src/PowerShellUniversal.Apps.HerdManager/functions/private/Invoke-UniversalSQLiteQuery.ps1
+++ b/src/PowerShellUniversal.Apps.HerdManager/functions/private/Invoke-UniversalSQLiteQuery.ps1
@@ -10,7 +10,7 @@ function Invoke-UniversalSQLiteQuery {
 
     # Verify sqlite3 is available
     if (-not (Get-Command sqlite3 -ErrorAction SilentlyContinue)) {
-        throw "sqlite3 command not found. Please install SQLite."
+        throw "sqlite3 command not found. Download sqlite3 from https://www.sqlite.org/download.html and add it to your system PATH. If running under PowerShell Universal, restart the PSU service after updating PATH."
     }
 
     # Verify database exists

--- a/src/PowerShellUniversal.Apps.HerdManager/functions/public/Invoke-UniversalSQLiteQuery.ps1
+++ b/src/PowerShellUniversal.Apps.HerdManager/functions/public/Invoke-UniversalSQLiteQuery.ps1
@@ -30,7 +30,7 @@ function Invoke-UniversalSQLiteQuery {
     
     # Verify sqlite3 is available
     if (-not (Get-Command sqlite3 -ErrorAction SilentlyContinue)) {
-    throw "sqlite3 command not found. Please install SQLite."
+    throw "sqlite3 command not found. Download sqlite3 from https://www.sqlite.org/download.html and add it to your system PATH. If running under PowerShell Universal, restart the PSU service after updating PATH."
     }
     
     # Verify database exists


### PR DESCRIPTION
## Summary

When installing Herd Manager from the PSU Gallery, the app fails to start with a generic "module could not be loaded" error and a .NET stack trace. The actual root cause (sqlite3 CLI not found in PATH) is buried and never surfaces in the PSU app log, leaving the admin with no actionable guidance.

This is a minimal fix that:

- **Replaces the generic error message** in all three copies of `Invoke-UniversalSQLiteQuery` with a specific message that includes the sqlite3 download URL and instructions for updating the system PATH (including the PSU service restart requirement)
- **Wraps the `.psm1` initialization in try/catch** and uses `Write-PSULog` to surface the real error in the PSU app log with a prominent banner, so admins see it immediately instead of just a stack trace

### Before

```
[Error] [App-Herd Manager] Startup: The module 'PowerShellUniversal.Apps.HerdManager'
could not be loaded. For more information, run 'Import-Module PowerShellUniversal.Apps.HerdManager'.
```

### After

```
[Error] [App-Herd Manager]
========================================================================
 HERD MANAGER - INITIALIZATION FAILED
========================================================================
 sqlite3 command not found.
 Download sqlite3 from https://www.sqlite.org/download.html and add it to your system PATH.
 If running under PowerShell Universal, restart the PSU service after updating PATH.
========================================================================
```

## Context

I discovered this while trying to evaluate the app via PSU Gallery install on a clean system. The lack of a useful error message cost me several hours of troubleshooting. This fix would have saved that time entirely.

This PR intentionally keeps changes minimal — it does not alter the sqlite3 CLI dependency or the database path behavior. It only improves error reporting so the next person who hits this issue knows exactly what to do.

**Note:** The current code depends on `sqlite3.exe` being in the system PATH, but the README lists PSSQLite (a PowerShell module) as the prerequisite — not the sqlite3 CLI binary. These are different dependencies, and the mismatch is a source of confusion for new users. See the companion PR on the `setup-bug-fixes` branch which addresses this by replacing the sqlite3 CLI dependency with PSSQLite entirely, allowing the app to be set up completely from within the PSU interface.

## Test plan

- [ ] Remove sqlite3 from system PATH
- [ ] Install module via PSU Gallery (or restart PSU service with module installed)
- [ ] Verify the improved error message appears in the PSU app log (Apps > Herd Manager > Log)
- [ ] Add sqlite3 to system PATH and restart PSU service
- [ ] Verify the app starts successfully
- [ ] Run `Import-Module` manually without sqlite3 in PATH and verify the improved error message appears in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)